### PR TITLE
Adresses the EADDRINUSE-Issue when debugging with node > 0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,11 @@ module.exports = function (sails) {
       if (!taskName) {
         taskName = '';
       }
+      
+      var execArgs = process.execArgv.slice(0);
+      if(execArgs.indexOf('--debug') !== -1) {
+        execArgs.splice(execArgs.indexOf('--debug'),1)
+      }
 
       // Fork Grunt child process
       var child = ChildProcess.fork(
@@ -89,7 +94,8 @@ module.exports = function (sails) {
         // opts to pass to node's `child_process` logic
         {
           silent: true,
-          stdio: 'pipe'
+          stdio: 'pipe',
+          execArgv: execArgs
         }
       );
 


### PR DESCRIPTION
Same code as in the grunt-hook, see:
https://github.com/balderdashy/sails/blob/88ffc0ed9949f8c74ea390efb5610b0e378fa02c/lib/hooks/grunt/index.js
